### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@ def configurations = [
 	// Linux 8
     [ platform: "linux", jdk: "8", jenkins: null ],
     // windows 8
-    [ platform: "windows", jdk: "8", jenkins: minimumLTS, javaLevel: "8" ],
+    [ platform: "windows", jdk: "8", jenkins: minimumLTS ],
     // Linux 11
-    [ platform: "linux", jdk: "11", jenkins: minimumLTS, javaLevel: "8" ],
+    [ platform: "linux", jdk: "11", jenkins: minimumLTS ],
 ]
 
 buildPlugin(configurations: configurations)


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.