### PR TITLE
fix for sumoupload failing when used from agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Please visit [Releases](https://github.com/jenkinsci/sumologic-publisher-plugin/releases) page.
 
+## v2.2.5
+- Fixed "SumoUpload failure when using on agent" [bug](https://github.com/jenkinsci/sumologic-publisher-plugin/issues/39)
+
 ## v2.2.4
 - Fixed [SECURITY-3117](https://issues.jenkins.io/browse/SECURITY-3117)
 - Upgrade htmlUnit from 2.x to 3.x

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/model/PluginConfiguration.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/model/PluginConfiguration.java
@@ -18,6 +18,13 @@ public class PluginConfiguration implements Serializable {
     private boolean jobStatusLogEnabled;
     private boolean jobConsoleLogEnabled;
     private boolean scmLogEnabled;
+ // Proxy settings
+    private boolean enableProxy = false;
+    private String proxyHost = "";
+    private int proxyPort = -1;
+    private boolean enableProxyAuth = false;
+    private String proxyAuthUsername = "";
+    private String proxyAuthPassword = "";
 
     public PluginConfiguration(PluginDescriptorImpl pluginDescriptor) {
         this.sumoLogicEndpoint = pluginDescriptor.getUrl();
@@ -31,6 +38,12 @@ public class PluginConfiguration implements Serializable {
         this.jobStatusLogEnabled = pluginDescriptor.isJobStatusLogEnabled();
         this.jobConsoleLogEnabled = pluginDescriptor.isJobConsoleLogEnabled();
         this.scmLogEnabled = pluginDescriptor.isScmLogEnabled();
+        this.enableProxy=pluginDescriptor.getEnableProxy();
+        this.proxyHost=pluginDescriptor.getProxyHost();
+        this.proxyPort=pluginDescriptor.getProxyPort();
+        this.enableProxyAuth=pluginDescriptor.getEnableProxyAuth();
+        this.proxyAuthUsername=pluginDescriptor.getProxyAuthUsername();
+        this.proxyAuthPassword=pluginDescriptor.getProxyAuthPassword();
     }
 
     public String getSumoLogicEndpoint() {
@@ -120,4 +133,52 @@ public class PluginConfiguration implements Serializable {
     public void setScmLogEnabled(boolean scmLogEnabled) {
         this.scmLogEnabled = scmLogEnabled;
     }
+
+	public String getProxyAuthPassword() {
+		return proxyAuthPassword;
+	}
+
+	public void setProxyAuthPassword(String proxyAuthPassword) {
+		this.proxyAuthPassword = proxyAuthPassword;
+	}
+
+	public String getProxyAuthUsername() {
+		return proxyAuthUsername;
+	}
+
+	public void setProxyAuthUsername(String proxyAuthUsername) {
+		this.proxyAuthUsername = proxyAuthUsername;
+	}
+
+	public boolean isEnableProxyAuth() {
+		return enableProxyAuth;
+	}
+
+	public void setEnableProxyAuth(boolean enableProxyAuth) {
+		this.enableProxyAuth = enableProxyAuth;
+	}
+
+	public int getProxyPort() {
+		return proxyPort;
+	}
+
+	public void setProxyPort(int proxyPort) {
+		this.proxyPort = proxyPort;
+	}
+
+	public String getProxyHost() {
+		return proxyHost;
+	}
+
+	public void setProxyHost(String proxyHost) {
+		this.proxyHost = proxyHost;
+	}
+
+	public boolean isEnableProxy() {
+		return enableProxy;
+	}
+
+	public void setEnableProxy(boolean enableProxy) {
+		this.enableProxy = enableProxy;
+	}
 }

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/LogSender.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/LogSender.java
@@ -69,18 +69,18 @@ public class LogSender {
         };
         
         //proxy enablement
-        PluginDescriptorImpl descriptor = PluginDescriptorImpl.getInstance();
-        enableProxy = descriptor.getEnableProxy();
-		enableProxyAuth = descriptor.getEnableProxyAuth();
+        PluginConfiguration pluginConfig = PluginDescriptorImpl.getPluginConfiguration();
+        enableProxy = pluginConfig.isEnableProxy();
+		enableProxyAuth = pluginConfig.isEnableProxyAuth();
 		CredentialsProvider credsProvider = null;
 		if (this.enableProxy) {
-			String proxyHost = descriptor.getProxyHost();
-			int proxyPort = descriptor.getProxyPort();
+			String proxyHost = pluginConfig.getProxyHost();
+			int proxyPort = pluginConfig.getProxyPort();
 			if (enableProxyAuth) {
 				AuthScope authScope = new AuthScope(proxyHost, proxyPort);
 				// Setting the credentials
-				String proxyAuthUsername = descriptor.getProxyAuthUsername();
-				String proxyAuthPassword = descriptor.getProxyAuthPassword();
+				String proxyAuthUsername = pluginConfig.getProxyAuthUsername();
+				String proxyAuthPassword = pluginConfig.getProxyAuthPassword();
 				org.apache.http.auth.UsernamePasswordCredentials creds = new org.apache.http.auth.UsernamePasswordCredentials(
 						proxyAuthUsername, proxyAuthPassword);
 				credsProvider = new BasicCredentialsProvider();


### PR DESCRIPTION
Issue was reported here : https://github.com/jenkinsci/sumologic-publisher-plugin/issue…s/39
In previous release proxy feature was enabled which needed proxy related parameters from jenkins instance. We were getting this instance from localContext, assuming that the plugin code will run only on build-in node, this caused a failure when this code was executed from remote context (agent). As part of the fix, jenkins instance is now fetched from another method which will make remote call to jenkins to get the proxy related parameters if running from remote context.

### Testing done
Testing involved a setup with an agent node. After the fix was deployed, did not see any jenkins.instance missing error.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
