### PR TITLE
SUMO-268363 | Groovy script fix for setting url as instance of secret…

### DIFF
--- a/src/main/groovy/com/sumologic/jenkins/jenkinssumologicplugin/SumoLogicPublisherConfiguration.groovy
+++ b/src/main/groovy/com/sumologic/jenkins/jenkinssumologicplugin/SumoLogicPublisherConfiguration.groovy
@@ -1,6 +1,7 @@
 package com.sumologic.jenkins.jenkinssumologicplugin
 
 import jenkins.model.Jenkins
+import hudson.util.Secret
 
 /**
 
@@ -17,7 +18,7 @@ def sumoLogic = Jenkins.get().getDescriptor(SumoBuildNotifier.class)
 
 sumoLogic.setQueryPortal('service.eu.sumologic.com')
 sumoLogic.setMetricDataPrefix('jenkinsMetricDataPrefix')
-sumoLogic.setUrl('https://<get_your_sumologic_http_source_url_here>')
+sumoLogic.setUrl(Secret.fromString('https://<get_your_sumologic_http_source_url_here>'))
 sumoLogic.setSourceCategory('jenkins')
 sumoLogic.setKeepOldConfigData(false)
 sumoLogic.setMetricDataEnabled(true)


### PR DESCRIPTION
… and not string

<!-- Please describe your pull request here. -->
We are using this groovy code : [https://github.com/jenkinsci/sumologic-publisher-plugin/blob/master/src/main/groov[…]s/jenkinssumologicplugin/SumoLogicPublisherConfiguration.groovy](https://github.com/jenkinsci/sumologic-publisher-plugin/blob/master/src/main/groovy/com/sumologic/jenkins/jenkinssumologicplugin/SumoLogicPublisherConfiguration.groovy) for automating the jenkins plugin config. But the problem is that its trying to set sumo http url as a string [here](https://github.com/jenkinsci/sumologic-publisher-plugin/blob/master/src/main/groovy/com/sumologic/jenkins/jenkinssumologicplugin/SumoLogicPublisherConfiguration.groovy#L20). But in the plugin code the url is declared as a [Secret](https://javadoc.jenkins-ci.org/hudson/util/Secret.html) , and the setter for the property accepts a Secret and not a string in the [code](https://github.com/jenkinsci/sumologic-publisher-plugin/blob/master/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java#L337), thus the error message MissingMethodException with no signature is encountered.Fix for this is to change the groovy script to change the string into an instance of secret like done [here ](https://github.com/jenkinsci/sumologic-publisher-plugin/blob/master/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java#L129). We have added import statement for Secret and convert the string to instance of secret using Secret.fromString method to call the set url method. Since the changes are only for automation of the plugin in groovy script - new plugin release is not required

JIRA: https://sumologic.atlassian.net/browse/SUMO-268363 

### Testing done
I have reproduced the issue on my local jenkins and was able to fix and verify with the above fix.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
